### PR TITLE
Replace accidentally dropped help signals

### DIFF
--- a/data/windowMain.ui
+++ b/data/windowMain.ui
@@ -437,6 +437,7 @@
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
+                        <signal name="activate" handler="online_help" swapped="no"/>
                       </object>
                     </child>
                     <child>
@@ -454,6 +455,7 @@
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
+                        <signal name="activate" handler="show_about" swapped="no"/>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Fixes Help>About and Help>Help buttons
