### PR TITLE
Use help: instead of ghelp:

### DIFF
--- a/src/lyricue
+++ b/src/lyricue
@@ -13183,7 +13183,7 @@ sub firstrun_bible {
 #
 sub online_help {
     debug("Load Documentation");
-    my $command = "xdg-open ghelp:lyricue";
+    my $command = "xdg-open help:lyricue";
     system($command);
 }
 


### PR DESCRIPTION
GitHub's online diff viewer isn't showing the right result for me.

Anyway, it needs to be `help:lyricue` not `ghelp:lyricue` in `src/lyricue`
