### PR TITLE
Incorporate Ubuntu patches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ lyricuedoc_DATA = \
 	COPYING\
 	AUTHORS\
 	ChangeLog\
-	INSTALL\
 	NEWS \
 	Development.txt \
     song_template.txt \

--- a/data/lyricue.desktop
+++ b/data/lyricue.desktop
@@ -1,10 +1,9 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Type=Application
 Exec=lyricue
 Icon=/usr/share/lyricue/lyricue-icon.png
 Terminal=false
 Name=Lyricue
-Categories=AudioVideo
+Categories=AudioVideo;
 Comment=The GNU Lyric Display System

--- a/data/lyricue_display.desktop
+++ b/data/lyricue_display.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Type=Application
 Exec=lyricue_display
@@ -7,6 +6,6 @@ Icon=/usr/share/lyricue/lyricue-icon.png
 Terminal=false
 Name=Lyricue Server
 Comment=The GNU Lyric Display System Display
-Categories=AudioVideo
+Categories=AudioVideo;
 StartupNotify=true
 X-Desktop-File-Install-Version=0.3

--- a/src/lyricue
+++ b/src/lyricue
@@ -10,7 +10,7 @@
 
 =head1 NAME
 
-lyricue
+lyricue - the GNU Lyric Display System
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Here's some minor fixes that Ubuntu's been carrying as patches.

Although the very latest standard is that trailing semicolons are [optional](https://cgit.freedesktop.org/xdg/desktop-file-utils/tree/NEWS) for `Categories`, I expect a lot of things still expect them to be there for now.
